### PR TITLE
Adiciando Referencia para executar os testes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -4,31 +4,38 @@
 
 Nós recomendamos a utilização do [Docker](https://www.docker.com/) para execução da nossa plataforma, assim você não precisará configurar seu ambiente.
 
-### Utilizando Docker
+### Rodando a API com Docker
 
-Primeiramente instale o Docker em sua maquina conforme a recomendações do site.
-Clone esse repositório na sua maquina.
-Entre na pasta clonada e execute
+- Primeiramente instale o Docker em sua maquina conforme a recomendações do site.
+- Clone esse repositório na sua maquina.
+- Entre na pasta clonada e execute:
 
 ```docker-compose up -d```
 
-Após a execução do comando o API deve estár disponível em
+Após a execução do comando o API deve estár disponível em:
 
 ```localhost:3000```
 
 Qualquer modificação em nos arquivos `.js` do projeto deverão recaregar o node automáticamente, pois este esta sendo executado através de um `nodemon`, assim é só codar que seu servidor irá atualizar automáticamente.
+
+### Rodando os testes com Docker
+
+Ha um `docker-compose` para rodar os testes da aplicação, nele irá criar um container com um banco novo para testes. Esse compose ira executar as migrations e seed no banco para testes, sequido dos testes unitários e aceitação e depois ira automáticamente desligar os containers para testes.
+
+Para executar os testes é só executar o sequinte comando:
+
+```docker-compose -f docker-compose.test.yml up --abort-on-container-exit | grep "test_1"```
 
 ### Utilizando Migrations
 
 A arquitetura do projeto foi pensada utilizando o [migration do Sequelize](http://sequelize.readthedocs.io/en/v3/docs/migrations/).
 
 Não há necessidade de instalar o `sequelize-cli` em sua maquina tendo em vista que este está presente dentro do container web.
-Caso precise executar/criar uma migration entre no container web utilizando o sequinte comando
 
-```docker exec -ti hades_web_1 bash```
+Caso precise executar/criar uma migration entre no container web utilizando o sequinte comando:
+
+```docker-compose exec --user 1000 web bash```
   
-(caso seu container web esteja com outro nome troque `hades_web_1` pelo nome do container)
-
 Dentro do container o `sequelize-cli` deverá estar presente em `/node_modules/.bin/sequelize` assim é só executar os comandos normalmente.
 
 Os arquivos criados estarão disponiveis também fora do container, então poderás utilizar seu editor favorito.

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,29 @@
+version: "2"
+services:
+        test:
+                build: .
+                command: ./wait-for test
+                volumes:
+                        - .:/app/
+                        - /app/node_modules
+                ports:
+                        - 3001:3000
+                depends_on:
+                        - postgres-test
+                networks:
+                  - test-net        
+                environment:
+                        DATABASE_URL: postgres://hades@postgres-test/hadesdb
+                        DB_USERNAME: hades
+                        DB_NAME: hadesdb
+                        DB_HOSTNAME: postgres-test
+        postgres-test:
+                image: postgres:latest
+                environment:
+                        POSTGRES_USER: hades
+                        POSTGRES_DB: hadesdb
+                networks:
+                  - test-net  
+networks:
+  test-net:
+    driver: bridge

--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "main": "app.js",
   "license": "MIT",
   "scripts": {
-    "test": "mocha 'test/unit/*.js'",
-    "test-acceptance": "mocha 'test/acceptance/*.js'",
+    "test": "mocha --exit 'test/unit/*.js'",
+    "test-acceptance": "mocha --exit 'test/acceptance/*.js'",
     "start": "node ./bin/www",
     "start-dev": "nodemon ./bin/www"
   },
   "dependencies": {
     "body-parser": "1.18.2",
     "express": "4.15.5",
-    "pg": "^6.4.1",
+    "pg": "^5.0.0",
     "pg-hstore": "^2.3.2",
     "sequelize": "^3.30.4",
     "sequelize-cli": "^3.0.0"

--- a/wait-for
+++ b/wait-for
@@ -9,4 +9,11 @@ echo "Postgres is up - executing command"
 
 ./node_modules/.bin/sequelize db:migrate 
 ./node_modules/.bin/sequelize db:seed:all
-npm run start-dev
+
+if [ "$1" = "test" ]; then
+  npm rum test
+  npm run test-acceptance
+  shutdown -h now
+else
+  npm run start-dev
+fi


### PR DESCRIPTION
Percebemos que faltou uma forma de executar os testes utilizando o Docker, logo criei um docker-compose para executar os testes e adicionei os comandos na descrição do projeto.