### PR TITLE
Trocando Referencias de Postgres para Mysql

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-node_modules/
+/node_modules/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -4,31 +4,38 @@
 
 Nós recomendamos a utilização do [Docker](https://www.docker.com/) para execução da nossa plataforma, assim você não precisará configurar seu ambiente.
 
-### Utilizando Docker
+### Rodando a API com Docker
 
-Primeiramente instale o Docker em sua maquina conforme a recomendações do site.
-Clone esse repositório na sua maquina.
-Entre na pasta clonada e execute
+- Primeiramente instale o Docker em sua maquina conforme a recomendações do site.
+- Clone esse repositório na sua maquina.
+- Entre na pasta clonada e execute:
 
 ```docker-compose up -d```
 
-Após a execução do comando o API deve estár disponível em
+Após a execução do comando o API deve estár disponível em:
 
 ```localhost:3000```
 
 Qualquer modificação em nos arquivos `.js` do projeto deverão recaregar o node automáticamente, pois este esta sendo executado através de um `nodemon`, assim é só codar que seu servidor irá atualizar automáticamente.
+
+### Rodando os testes com Docker
+
+Ha um `docker-compose` para rodar os testes da aplicação, nele irá criar um container com um banco novo para testes. Esse compose ira executar as migrations e seed no banco para testes, sequido dos testes unitários e aceitação e depois ira automáticamente desligar os containers para testes.
+
+Para executar os testes é só executar o sequinte comando:
+
+```docker-compose -f docker-compose.test.yml up --abort-on-container-exit | grep "test_1"```
 
 ### Utilizando Migrations
 
 A arquitetura do projeto foi pensada utilizando o [migration do Sequelize](http://sequelize.readthedocs.io/en/v3/docs/migrations/).
 
 Não há necessidade de instalar o `sequelize-cli` em sua maquina tendo em vista que este está presente dentro do container web.
-Caso precise executar/criar uma migration entre no container web utilizando o sequinte comando
 
-```docker exec -ti hades_web_1 bash```
+Caso precise executar/criar uma migration entre no container web utilizando o sequinte comando:
+
+```docker-compose exec --user 1000 web bash```
   
-(caso seu container web esteja com outro nome troque `hades_web_1` pelo nome do container)
-
 Dentro do container o `sequelize-cli` deverá estar presente em `/node_modules/.bin/sequelize` assim é só executar os comandos normalmente.
 
 Os arquivos criados estarão disponiveis também fora do container, então poderás utilizar seu editor favorito.

--- a/config/config.js
+++ b/config/config.js
@@ -3,26 +3,26 @@ const fs = require('fs');
 module.exports = {
 	development: {
 		username: process.env.DB_USERNAME,
-		password: null,
+		password: process.env.DB_PASSWORD,
 		database: process.env.DB_NAME,
 		host: process.env.DB_HOSTNAME,
-		dialect: 'postgres',
+		dialect: 'mysql',
         seederStorage: 'sequelize'
 	},
 	test: {
 		username: process.env.DB_USERNAME,
-		password: null,
+		password: process.env.DB_PASSWORD,
 		database: process.env.DB_NAME,
 		host: process.env.DB_HOSTNAME,
-		dialect: 'postgres',
+		dialect: 'mysql',
         seederStorage: 'sequelize'
 	},
 	production: {
 		username: process.env.DB_USERNAME,
-		password: null,
+		password: process.env.DB_PASSWORD,
 		database: process.env.DB_NAME,
 		host: process.env.DB_HOSTNAME,
-		dialect: 'postgres',
+		dialect: 'mysql',
         seederStorage: 'sequelize'
 	}
 };

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,29 @@
+version: "2"
+services:
+        test:
+                build: .
+                command: ./wait-for test
+                volumes:
+                        - .:/app/
+                        - /app/node_modules
+                ports:
+                        - 3001:3000
+                depends_on:
+                        - postgres-test
+                networks:
+                  - test-net        
+                environment:
+                        DATABASE_URL: postgres://hades@postgres-test/hadesdb
+                        DB_USERNAME: hades
+                        DB_NAME: hadesdb
+                        DB_HOSTNAME: postgres-test
+        postgres-test:
+                image: postgres:latest
+                environment:
+                        POSTGRES_USER: hades
+                        POSTGRES_DB: hadesdb
+                networks:
+                  - test-net  
+networks:
+  test-net:
+    driver: bridge

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,19 +9,22 @@ services:
                 ports:
                         - 3001:3000
                 depends_on:
-                        - postgres-test
+                        - mysql-test
                 networks:
                   - test-net        
                 environment:
-                        DATABASE_URL: postgres://hades@postgres-test/hadesdb
-                        DB_USERNAME: hades
-                        DB_NAME: hadesdb
-                        DB_HOSTNAME: postgres-test
-        postgres-test:
-                image: postgres:latest
+                  DATABASE_URL: mysql://hades:hades@mysql-test/hadesdb
+                  DB_USERNAME: hades
+                  DB_PASSWORD: hades
+                  DB_NAME: hadesdb
+                  DB_HOSTNAME: mysql-test
+        mysql-test:
+                image: mysql:latest
                 environment:
-                        POSTGRES_USER: hades
-                        POSTGRES_DB: hadesdb
+                        MYSQL_ROOT_PASSWORD: hadespwd
+                        MYSQL_DATABASE: hadesdb
+                        MYSQL_USER: hades
+                        MYSQL_PASSWORD: hades
                 networks:
                   - test-net  
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,14 +9,18 @@ services:
                 ports:
                         - 3000:3000
                 depends_on:
-                        - postgres
+                        - mysql
                 environment:
-                        DATABASE_URL: postgres://hades@postgres/hadesdb
-                        DB_USERNAME: hades
-                        DB_NAME: hadesdb
-                        DB_HOSTNAME: postgres
-        postgres:
-                image: postgres:latest
+                  DATABASE_URL: mysql://hades:hades@mysql/hadesdb
+                  DB_PASSWORD: hades
+                  DB_USERNAME: hades
+                  DB_PASSWORD: hades
+                  DB_NAME: hadesdb
+                  DB_HOSTNAME: mysql
+        mysql:
+                image: mysql:latest
                 environment:
-                        POSTGRES_USER: hades
-                        POSTGRES_DB: hadesdb
+                        MYSQL_ROOT_PASSWORD: hadespwd
+                        MYSQL_DATABASE: hadesdb
+                        MYSQL_USER: hades
+                        MYSQL_PASSWORD: hades

--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "main": "app.js",
   "license": "MIT",
   "scripts": {
-    "test": "mocha 'test/unit/*.js'",
-    "test-acceptance": "mocha 'test/acceptance/*.js'",
+    "test": "mocha --exit 'test/unit/*.js'",
+    "test-acceptance": "mocha --exit 'test/acceptance/*.js'",
     "start": "node ./bin/www",
     "start-dev": "nodemon ./bin/www"
   },
   "dependencies": {
     "body-parser": "1.18.2",
     "express": "4.15.5",
-    "pg": "^6.4.1",
+    "pg": "^5.0.0",
     "pg-hstore": "^2.3.2",
     "sequelize": "^3.30.4",
     "sequelize-cli": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   "dependencies": {
     "body-parser": "1.18.2",
     "express": "4.15.5",
-    "pg": "^5.0.0",
-    "pg-hstore": "^2.3.2",
+    "mysql": "^2.15.0",
     "sequelize": "^3.30.4",
     "sequelize-cli": "^3.0.0"
   },

--- a/wait-for
+++ b/wait-for
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 until node wait.js; do
-echo "Postgres is unavailable - sleeping"
+echo "Mysql is unavailable - sleeping"
   sleep 1
 done
 
-echo "Postgres is up - executing command"
+echo "Mysql is up - executing command"
 
 ./node_modules/.bin/sequelize db:migrate 
 ./node_modules/.bin/sequelize db:seed:all

--- a/wait-for
+++ b/wait-for
@@ -9,4 +9,11 @@ echo "Postgres is up - executing command"
 
 ./node_modules/.bin/sequelize db:migrate 
 ./node_modules/.bin/sequelize db:seed:all
-npm run start-dev
+
+if [ "$1" = "test" ]; then
+  npm rum test
+  npm run test-acceptance
+  shutdown -h now
+else
+  npm run start-dev
+fi


### PR DESCRIPTION
Com a entrada no Umbler, acho melhor trocarmos para Mysql para podermos utilizar o banco de dados oferencido pelo serviço, dessa forma achei melhor trocarmos nosso ambiente de Dev para Mysql também para evitarmos divergencias.