### PR TITLE
Arrumar Execução no Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+text eol=lf

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Qualquer modificação em nos arquivos `.js` do projeto deverão recaregar o nod
 
 #### Problemas com Windows
 
-Caso você faça clone do repositório e após um ````docker-compose up -d``` recebeu a mensagem de `no such file or directory`, pode ser que seu problema seja com EOL de arquivos do Windows (CRLF). Para isso é bem simples de resolver, delete seu clone do repositorio e configure seu GIT para não clonar automáticamente com CRLF com sequinte comando:
+Caso você faça clone do repositório e após um ```docker-compose up -d``` recebeu a mensagem de `no such file or directory`, pode ser que seu problema seja com EOL de arquivos do Windows (CRLF). Para isso é bem simples de resolver, delete seu clone do repositorio e configure seu GIT para não clonar automáticamente com CRLF com sequinte comando:
 ```git config --global core.autocrlf false```
 
 Após isso é só clonar novamente e repositório que deve resolver seu problema. 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Após a execução do comando o API deve estár disponível em:
 
 Qualquer modificação em nos arquivos `.js` do projeto deverão recaregar o node automáticamente, pois este esta sendo executado através de um `nodemon`, assim é só codar que seu servidor irá atualizar automáticamente.
 
+#### Problemas com Windows
+
+Caso você faça clone do repositório e após um ````docker-compose up -d``` recebeu a mensagem de `no such file or directory`, pode ser que seu problema seja com EOL de arquivos do Windows (CRLF). Para isso é bem simples de resolver, delete seu clone do repositorio e configure seu GIT para não clonar automáticamente com CRLF com sequinte comando:
+```git config --global core.autocrlf false```
+
+Após isso é só clonar novamente e repositório que deve resolver seu problema. 
+
 ### Rodando os testes com Docker
 
 Ha um `docker-compose` para rodar os testes da aplicação, nele irá criar um container com um banco novo para testes. Esse compose ira executar as migrations e seed no banco para testes, sequido dos testes unitários e aceitação e depois ira automáticamente desligar os containers para testes.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Qualquer modificação em nos arquivos `.js` do projeto deverão recaregar o nod
 #### Problemas com Windows
 
 Caso você faça clone do repositório e após um ```docker-compose up -d``` recebeu a mensagem de `no such file or directory`, pode ser que seu problema seja com EOL de arquivos do Windows (CRLF). Para isso é bem simples de resolver, delete seu clone do repositorio e configure seu GIT para não clonar automáticamente com CRLF com sequinte comando:
+
 ```git config --global core.autocrlf false```
 
 Após isso é só clonar novamente e repositório que deve resolver seu problema. 


### PR DESCRIPTION
Devido a configuração padrão de EOL do Windows com CRLF isso acaba dando alguns problema na execução de arquivos de Shell Script.

Existem algumas formas de resolver isso como o [dos2unix](http://dos2unix.sourceforge.net/), porém achei mais simples para nosso projeto seria apenas resolver na hora do clone do projeto, evitando que o git puxe os arquivos com CRLF.

Isso deve resolver os problemas que estávamos tendo com usuários do SO Windows.